### PR TITLE
Fixed like button functionality

### DIFF
--- a/app/assets/stylesheets/components/_main-card.scss
+++ b/app/assets/stylesheets/components/_main-card.scss
@@ -1,6 +1,6 @@
 .card {
     height: 80vh;
-    padding: 40px;
+    padding: 30px;
     background-color: white;
     border-radius: 4px;
     box-shadow: 1px 1px 20px rgba(0, 0, 0, 0.1);
@@ -85,6 +85,7 @@
 .main-card-image-likes-button{
   font-size: 16px;
   margin: 2px;
+  padding: 0px;
 }
 
 .main-card-image-like::after {

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,8 +1,8 @@
 class LikesController < ApplicationController
   before_action :authenticate_user!
 
-  before_action :set_spot, only: %i(calculate_number_of_likes upvote downvote)
   before_action :set_like, only: %i(calculate_number_of_likes upvote downvote)
+  before_action :set_spot, only: %i(calculate_number_of_likes upvote downvote)
 
   include Pundit
   after_action :verify_authorized, except: %i(number_of_likes set_spot), unless: :skip_pundit?
@@ -34,7 +34,7 @@ class LikesController < ApplicationController
   end
 
   def set_spot
-    @spot = Spot.find(params[:id])
+    @spot = @like.spot
   end
 
   def vote_value

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -27,8 +27,8 @@ class SpotsController < ApplicationController
 
   def show
     @review = Review.new
-    if Like.where(spot_id: @spot.id) == []
-      @like = Like.new(spot: @spot, value: 0)
+    if Like.where(spot_id: @spot.id, user_id: current_user.id) == []
+      @like = Like.create(spot: @spot, user: current_user, value: 0)
     else
       @like = Like.where(spot_id: @spot.id).first
     end

--- a/app/views/spots/_spot-card.html.erb
+++ b/app/views/spots/_spot-card.html.erb
@@ -1,16 +1,17 @@
 <div class="spot-title">
 
   <div class="row">
-    <div class="col-md-9">
+    <div class="col-md-8">
       <h4><strong><%= @spot.name %></strong></h4>
     </div>
 
-    <div class="col-md-3">
+    <div class="col-md-4">
       <div class="main-card-image-uploadedby-favorites">
         <div class="main-card-image-favorites">
           <% if user_signed_in? %>
-            <p class="small btn"><%= link_to "<i class='fas fa-thumbs-up'></i>".html_safe, upvote_like_path(@spot.id) %> </p>
-            <p class="small btn"><%= link_to "<i class='fas fa-thumbs-down'></i>".html_safe, downvote_like_path(@spot.id) %></p>
+            <p><%= @no_of_likes %></p>
+            <p class="small btn main-card-image-likes-button"><%= link_to "<i class='fas fa-thumbs-up'></i>".html_safe, upvote_like_path(@like) %> </p>
+            <p class="small btn main-card-image-likes-button"><%= link_to "<i class='fas fa-thumbs-down'></i>".html_safe, downvote_like_path(@like) %></p>
             <br><br>
           <% end %>
         </div>


### PR DESCRIPTION
set_like could not find the correct like. set_like is now executed before set_spot. @like is the argument of the path that is specified in the link (i.e., the link from the upvote or downvote button). Also, the @like was not saved when loading a spots#show page before so that the likes#set_spot could not find any existing like in the database for the user-spot combination.